### PR TITLE
Fixes file path matching for resource files on Windows

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -325,7 +325,7 @@ function _createWorkspaceFile(filePath: string, fileContents: string, createFn: 
 }
 
 function _filePathFromUri(uri: string): string {
-  return Uri.parse(uri).path;
+  return Uri.parse(uri).fsPath;
 }
 
 function _textPositionToLocation(position: TextDocumentPositionParams) {


### PR DESCRIPTION
Resource file detection was failing on Windows with the message 'Keyword definition not found from the workspace'.
`Uri.fsPath` was used when parsing all files but `Uri.path` was used to find the cached keywords later.

Fixes #16.

I tested this on Windows. I have not yet been able to test it on Mac.