### PR TITLE
Support duplicate keywords with namespace resolution from Resource filenames

### DIFF
--- a/server/src/intellisense/search-tree.ts
+++ b/server/src/intellisense/search-tree.ts
@@ -83,6 +83,43 @@ export class KeywordContainer extends SymbolContainer<UserKeyword> {
 }
 
 /**
+ * Container for global keywords. Indexed without the namespace.
+ * Keywords from different namespaces with the same name are grouped in an array.
+ */
+export class GlobalKeywordContainer extends SymbolContainer<UserKeyword[]> {
+  public addKeyword(item: UserKeyword) {
+    this.add([item]);
+
+    const key = item.id.name.toLowerCase();
+    const keywords = this.tree.get(key) as UserKeyword[];
+    if (keywords) {
+      keywords.push(item);
+    } else {
+      this.tree.set(key, [ item ]);
+    }
+  }
+
+  public removeKeyword(item: UserKeyword) {
+    this.remove([item]);
+
+    const key = item.id.name.toLowerCase();
+    const keywords = this.tree.get(key) as UserKeyword[];
+    if (keywords) {
+      const update = keywords.filter(keyword => keyword.id.fullName !== item.id.fullName);
+      if (update.length > 0) {
+        this.tree.set(key, update);
+      } else {
+        this.tree.del(key);
+      }
+    }
+  }
+
+  protected getKey(item: UserKeyword[]) {
+    return item[0].id.fullName;
+  }
+}
+
+/**
  * Container for variables
  */
 export class VariableContainer extends SymbolContainer<VariableDeclaration> {
@@ -125,7 +162,6 @@ export class VariableContainer extends SymbolContainer<VariableDeclaration> {
 
 export interface Symbols {
   keywords: KeywordContainer;
-
   variables: VariableContainer;
 }
 

--- a/server/src/intellisense/symbol-provider.ts
+++ b/server/src/intellisense/symbol-provider.ts
@@ -3,7 +3,7 @@ import WorkspaceFile from "./workspace/workspace-file";
 import { nodeLocationToRange } from "../utils/position";
 import { SymbolKind } from "vscode-languageserver";
 import { formatVariable } from "./formatters";
-import { isVariableDeclaration } from "./type-guards";
+import { isVariableDeclaration, isUserKeyword } from "./type-guards";
 
 import {
   VariableDeclaration,
@@ -78,6 +78,14 @@ function _createIdMatcherFn(query: string) {
   const lowerQuery = query.toLowerCase();
 
   return (node: VariableDeclaration | UserKeyword | TestCase) => {
+    if (query.includes(".") && isUserKeyword(node)) {
+      // Query must be considered an explicit keyword to match this node.
+      // Only keywords with namespaces shall match.
+      if (node.id.namespace) {
+        return node.id.fullName.toLowerCase().includes(lowerQuery);
+      }
+    }
+
     const toMatch = isVariableDeclaration(node) ?
       formatVariable(node) : node.id.name;
 

--- a/server/src/intellisense/type-guards.ts
+++ b/server/src/intellisense/type-guards.ts
@@ -2,6 +2,7 @@ import {
   Node,
   Step,
   Identifier,
+  NamespacedIdentifier,
   Literal,
   TemplateLiteral,
   VariableExpression,
@@ -32,7 +33,11 @@ function isOfType(node: Node, typeName: string) {
 }
 
 export function isIdentifier(node: Node): node is Identifier {
-  return isOfType(node, "Identifier");
+  return isNamespacedIdentifier(node) || isOfType(node, "Identifier");
+}
+
+export function isNamespacedIdentifier(node: Node): node is NamespacedIdentifier {
+  return isOfType(node, "NamespacedIdentifier");
 }
 
 export function isVariableExpression(node: Node): node is VariableExpression {

--- a/server/src/intellisense/workspace/python-file.ts
+++ b/server/src/intellisense/workspace/python-file.ts
@@ -1,4 +1,5 @@
 import * as Trie from "node-ternary-search-trie";
+import * as path from "path";
 import { TestSuite } from "../../parser/models";
 import { DataTable } from "../../parser/table-models";
 import WorkspaceFile from "./workspace-file";
@@ -35,7 +36,8 @@ export function createPythonFile(
   absolutePath: string,
   relativePath: string,
 ): PythonFile {
-  const ast = pythonParser.parseFile(contents);
+  const namespace = path.parse(absolutePath).name;
+  const ast = pythonParser.parseFile(contents, namespace);
 
   return new PythonFile(absolutePath, relativePath, ast);
 }

--- a/server/src/intellisense/workspace/robot-file.ts
+++ b/server/src/intellisense/workspace/robot-file.ts
@@ -1,4 +1,4 @@
-import * as Trie from "node-ternary-search-trie";
+import * as path from "path";
 import { TestSuite } from "../../parser/models";
 import { DataTable } from "../../parser/table-models";
 import { FileParser as RobotParser } from "../../parser/parser";
@@ -37,7 +37,15 @@ export function createRobotFile(
   relativePath: string,
 ): RobotFile {
   const tables = robotParser.readTables(contents);
-  const ast    = robotParser.parseFile(tables);
+
+  // Set the namespace for all keywords to the file name.
+  // Robot docs:
+  //    Resource files are specified in the full keyword name, similarly as library names.
+  //    The name of the resource is derived from the basename of the resource file without the file extension.
+  // http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#handling-keywords-with-same-names
+  const namespace = path.parse(relativePath).name;
+
+  const ast = robotParser.parseFile(tables, namespace);
 
   return new RobotFile(absolutePath, relativePath, ast, tables);
 }

--- a/server/src/intellisense/workspace/workspace-file.ts
+++ b/server/src/intellisense/workspace/workspace-file.ts
@@ -1,4 +1,5 @@
 import * as _ from "lodash";
+import * as path from "path";
 import { TestSuite } from "../../parser/models";
 import {
   Symbols,
@@ -10,6 +11,9 @@ import {
 import Uri from "vscode-uri";
 
 abstract class WorkspaceFile implements Symbols {
+  // The namespace for this file is based on the filename.
+  public namespace: string;
+
   // All the variables in the file
   public variables: VariableContainer;
 
@@ -30,6 +34,7 @@ abstract class WorkspaceFile implements Symbols {
 
     this.keywords  = keywords;
     this.variables = variables;
+    this.namespace = path.parse(this.filePath).name;
   }
 
   public get uri() {

--- a/server/src/intellisense/workspace/workspace.ts
+++ b/server/src/intellisense/workspace/workspace.ts
@@ -3,22 +3,27 @@ import * as Trie from "node-ternary-search-trie";
 import WorkspaceFile from "./workspace-file";
 import {
   KeywordContainer,
+  GlobalKeywordContainer,
   VariableContainer,
   removeFileSymbols
 } from "../search-tree";
+import { UserKeyword } from "../../parser/models";
 
 /**
  * A class that represents a workspace (=folder) open in VSCode
  */
-class Workspace {
-  // A tree of all global keywords in the workspace
-  public keywords = new KeywordContainer();
-
+export class Workspace {
   // A tree of all global variables in the workspace
   public variables = new VariableContainer();
 
+  // A tree of all global keywords in the workspace
+  private keywords = new GlobalKeywordContainer();
+
   // Mapping from filename: string -> file
   private filesByPath: Map<string, WorkspaceFile> = new Map();
+
+  // Mapping from WorkspaceFile namespace: string -> file
+  private filesByNamespace: Map<string, WorkspaceFile> = new Map();
 
   /**
    * Adds a file to the workspace
@@ -29,10 +34,11 @@ class Workspace {
     // Remove file first so its search tree is removed from global tree
     this.removeFileByPath(file.filePath);
 
-    this.keywords.copyFrom(file.keywords);
+    file.keywords.forEach((key, keyword) => this.keywords.addKeyword(keyword));
     this.variables.copyFrom(file.variables);
 
     this.filesByPath.set(file.filePath, file);
+    this.filesByNamespace.set(file.namespace, file);
   }
 
   /**
@@ -42,10 +48,40 @@ class Workspace {
   public removeFileByPath(filePath: string) {
     const existingFile = this.filesByPath.get(filePath);
     if (existingFile) {
-      removeFileSymbols(this, existingFile.ast);
+      existingFile.keywords.forEach((key, keyword) => this.keywords.removeKeyword(keyword));
+      const { ast } = existingFile;
+      if (ast && ast.variablesTable) {
+        ast.variablesTable.variables.forEach(variable => {
+          this.variables.remove(variable);
+        });
+      }
+      this.filesByNamespace.delete(existingFile.namespace);
     }
 
     this.filesByPath.delete(filePath);
+  }
+
+  /**
+   * Searchs the global workspace for matching keywords.
+   * Results are grouped by the matching keyword.
+   */
+  public findKeywords(textToSearch: string): UserKeyword[][] {
+    /* An example of the resulting array-of-arrays:
+     * [
+     *   [
+     *     { namespace: "Foo": keyword: "Find" },
+     *     { namespace: "Bar": keyword: "Find" },
+     *   ],
+     *   [
+     *     { namespace: "Bar": keyword: "DoThing" },
+     *   ]
+     * ]
+     */
+    return _(this.keywords.findByPrefix(textToSearch))
+    .flatten()
+    .groupBy((keyword: UserKeyword) => keyword.id.name)
+    .map((keywords: UserKeyword[]) => keywords)
+    .value();
   }
 
   /**
@@ -53,12 +89,17 @@ class Workspace {
    */
   public clear() {
     this.filesByPath = new Map();
-    this.keywords    = new KeywordContainer();
+    this.filesByNamespace = new Map();
+    this.keywords    = new GlobalKeywordContainer();
     this.variables   = new VariableContainer();
   }
 
   public getFile(filename) {
     return this.filesByPath.get(filename);
+  }
+
+  public getFileByNamespace(namespace) {
+    return this.filesByNamespace.get(namespace);
   }
 
   public getFiles() {

--- a/server/src/parser/keywords-table-parser.ts
+++ b/server/src/parser/keywords-table-parser.ts
@@ -28,8 +28,8 @@ const keywordSettings = new Set([
   "[Teardown]", "[Tags]", "[Timeout]"
 ]);
 
-export function parseKeywordsTable(dataTable: DataTable): KeywordsTable {
-  const keywordsTable = new KeywordsTable(dataTable.location);
+export function parseKeywordsTable(dataTable: DataTable, namespace: string): KeywordsTable {
+  const keywordsTable = new KeywordsTable(namespace, dataTable.location);
   let currentKeyword: UserKeyword;
 
   const iterator = new TableRowIterator(dataTable);

--- a/server/src/parser/parser.ts
+++ b/server/src/parser/parser.ts
@@ -21,7 +21,7 @@ export class FileParser {
     return tableReader.read(data);
   }
 
-  public parseFile(data: string | DataTable[]) {
+  public parseFile(data: string | DataTable[], namespace?: string) {
     let fileTables: DataTable[];
     if (typeof data === "string") {
       fileTables = this.readTables(data);
@@ -56,7 +56,7 @@ export class FileParser {
 
         testDataFile.variablesTable = parsedTable;
       } else if (KEYWORDS_TABLES.has(lowerCaseTableName)) {
-        const parsedTable = parseKeywordsTable(dataTable);
+        const parsedTable = parseKeywordsTable(dataTable, namespace);
 
         testDataFile.keywordsTable = parsedTable;
       } else if (TEST_CASES_TABLES.has(lowerCaseTableName)) {

--- a/server/src/parser/test/keywords-table-parser.test.ts
+++ b/server/src/parser/test/keywords-table-parser.test.ts
@@ -10,6 +10,7 @@ import {
   Step,
   CallExpression,
   Identifier,
+  NamespacedIdentifier,
   Literal,
   VariableExpression,
   ScalarDeclaration,
@@ -33,7 +34,7 @@ function parseAndAssert(tableDefinition: string, expected: KeywordsTable) {
 }
 
 function keywordsTable(location, keywords) {
-  return Object.assign(new KeywordsTable(location), { keywords });
+  return Object.assign(new KeywordsTable(undefined, location), { keywords });
 }
 
 function keyword(
@@ -132,6 +133,52 @@ Keyword Name
               location(2, 4, 3, 18)
             ),
             location(2, 4, 3, 18)
+          ),
+        ]
+      )
+    ]);
+
+    parseAndAssert(data, expected);
+  });
+
+  it("should parse steps with explicit keywords", () => {
+    const data =
+`*** Keywords ***
+Keyword Name
+    MyLibrary.Step 1    arg1      arg2
+    Deep.Library.Step 1    \${VAR}    a longer arg2
+`;
+
+    const expected = keywordsTable(location(0, 0, 4, 0), [
+      keyword(
+        location(1, 0, 3, 50),
+        new Identifier("Keyword Name", location(1, 0, 1, 12)),
+        [
+          new Step(
+            new CallExpression(
+              new NamespacedIdentifier("MyLibrary", "Step 1", location(2, 4, 2, 20)),
+              [
+                new Literal("arg1", location(2, 24, 2, 28)),
+                new Literal("arg2", location(2, 34, 2, 38)),
+              ],
+              location(2, 4, 2, 38)
+            ),
+            location(2, 4, 2, 38)
+          ),
+          new Step(
+            new CallExpression(
+              new NamespacedIdentifier("Deep.Library", "Step 1", location(3, 4, 3, 23)),
+              [
+                new VariableExpression(
+                  new Identifier("VAR", location(3, 29, 3, 32)),
+                  "Scalar",
+                  location(3, 27, 3, 33)
+                ),
+                new Literal("a longer arg2", location(3, 37, 3, 50)),
+              ],
+              location(3, 4, 3, 50)
+            ),
+            location(3, 4, 3, 50)
           ),
         ]
       )

--- a/server/src/parser/test/test-cases-table-parser.test.ts
+++ b/server/src/parser/test/test-cases-table-parser.test.ts
@@ -6,6 +6,7 @@ const parser = new FileParser();
 
 import {
   Identifier,
+  NamespacedIdentifier,
   CallExpression,
   Literal,
   TestCasesTable,
@@ -137,4 +138,49 @@ TestCas Name
     parseAndAssert(data, expected);
   });
 
+  it("should parse steps with explicit keywords", () => {
+    const data =
+`*** Test Cases ***
+TestCas Name
+    MyLibrary.Step 1    arg1      arg2
+    Deep.Library.Step 1    \${VAR}    a longer arg2
+`;
+
+    const expected = testCasesTable(location(0, 0, 4, 0), [
+      testCase(
+        location(1, 0, 3, 50),
+        new Identifier("TestCas Name", location(1, 0, 1, 12)),
+        [
+          new Step(
+            new CallExpression(
+              new NamespacedIdentifier("MyLibrary", "Step 1", location(2, 4, 2, 20)),
+              [
+                new Literal("arg1", location(2, 24, 2, 28)),
+                new Literal("arg2", location(2, 34, 2, 38)),
+              ],
+              location(2, 4, 2, 38)
+            ),
+            location(2, 4, 2, 38)
+          ),
+          new Step(
+            new CallExpression(
+              new NamespacedIdentifier("Deep.Library", "Step 1", location(3, 4, 3, 23)),
+              [
+                new VariableExpression(
+                  new Identifier("VAR", location(3, 29, 3, 32)),
+                  "Scalar",
+                  location(3, 27, 3, 33)
+                ),
+                new Literal("a longer arg2", location(3, 37, 3, 50)),
+              ],
+              location(3, 4, 3, 50)
+            ),
+            location(3, 4, 3, 50)
+          ),
+        ]
+      )
+    ]);
+
+    parseAndAssert(data, expected);
+  });
 });

--- a/server/src/python-parser/python-parser.ts
+++ b/server/src/python-parser/python-parser.ts
@@ -23,14 +23,14 @@ export class PythonParser {
    * @param data python file contents
    * @param filePath
    */
-  public parseFile(data: string): TestSuite {
+  public parseFile(data: string, namespace: string): TestSuite {
     const lineIndexes = getLineIndexes(data);
     const suiteRange = createRange(_.first(lineIndexes), _.last(lineIndexes));
 
     const keywords = findKeywords(data, lineIndexes);
 
     return Object.assign(new TestSuite(suiteRange), {
-      keywordsTable: Object.assign(new KeywordsTable(suiteRange), {
+      keywordsTable: Object.assign(new KeywordsTable(namespace, suiteRange), {
         keywords
       })
     });

--- a/server/src/python-parser/test/python-parser.test.ts
+++ b/server/src/python-parser/test/python-parser.test.ts
@@ -30,14 +30,14 @@ export function location(startLine, startColumn, endLine?, endColumn?) {
 const parser = new PythonParser();
 
 function parseAndAssert(data: string, expected: any) {
-  const actual = parser.parseFile(data);
+  const actual = parser.parseFile(data, undefined as string);
 
   chai.assert.deepEqual(actual, expected);
 }
 
 function createSuite(location, keywords) {
   return Object.assign(new TestSuite(location), {
-    keywordsTable: Object.assign(new KeywordsTable(location), {
+    keywordsTable: Object.assign(new KeywordsTable(undefined, location), {
       keywords
     })
   });


### PR DESCRIPTION
Hello,

I ran into a similar issue as requested in #15. I've attempted an implementation to address this and tested against my personal "spec" in a sample repository at [vscode-rf-language-server-robot-namespace-sample](https://github.com/edchapel/vscode-rf-language-server-robot-namespace-sample). The sample robot files include comments for what I would expect to happen based on the [Robot user docs](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#handling-keywords-with-same-names).

The changes in the PR introduce the idea of a `namespace` for UserKeywords and Steps. The `namespace` is the filename of the Resource without the extension. I added and updated tests where I've extended the keyword and test case parsing.

Unfortunately, I was not able to get the intellisense to suggest keywords from the Resources files.

Please let me know your thoughts on this PR.

Many thanks for the excellent VSCode plugin!

Ed