### PR TITLE
Support pipe separated format

### DIFF
--- a/server/src/parser/table-reader.ts
+++ b/server/src/parser/table-reader.ts
@@ -59,6 +59,7 @@ class LineReader {
     this.lineNumber = lineNumber;
     this.line = this.trimPipes(this.trimComments(line));
     this.position = 0;
+    this.readLeadingPipe();
 
     const row = new DataRow({
       start: {
@@ -93,14 +94,6 @@ class LineReader {
   }
 
   private trimPipes(line: string) {
-    // in case empty first cell, do not remove space after leading pipe
-    if (line.startsWith("| | ")) {
-      line = line.substring(1, line.length);
-    }
-    // remove mandatory leading pipe
-    if (line.startsWith("| ")) {
-      line = line.substring(2, line.length);
-    }
     // remove optional pipe at the end of line
     if (line.endsWith(" |")) {
       line = line.substring(0, line.length - 2);
@@ -159,9 +152,30 @@ class LineReader {
     return cell;
   }
 
-  private readWhitespaceOrPipe() {
-    while (!this.isEnd() && /(\s|\|)/.test(this.line.charAt(this.position))) {
+  private readLeadingPipe() {
+    // in case empty first cell, move position to empty cell
+    if (/^\|\s+\|\s.*/.test(this.line)) {
       this.position = this.position + 1;
+    } else if (this.line.startsWith("| ")) {
+      this.position = this.position + 2;
+    }
+  }
+
+  private readWhitespaceOrPipe() {
+    while (!this.isEnd()) {
+      // read pipe delimiter
+      if (this.line.startsWith(" | ", this.position)) {
+        this.position = this.position + 3;
+        continue;
+      }
+      
+      // read whitespace
+      if (/(\s)/.test(this.line.charAt(this.position))) {
+        this.position = this.position + 1;
+        continue;
+      }
+
+      break;
     }
   }
 

--- a/server/src/parser/table-reader.ts
+++ b/server/src/parser/table-reader.ts
@@ -168,7 +168,7 @@ class LineReader {
         this.position = this.position + 3;
         continue;
       }
-      
+
       // read whitespace
       if (/(\s)/.test(this.line.charAt(this.position))) {
         this.position = this.position + 1;

--- a/server/src/parser/test/table-reader.test.ts
+++ b/server/src/parser/test/table-reader.test.ts
@@ -10,8 +10,12 @@ import { createLocation, table, row } from "./test-helper";
 const reader = new TableReader();
 
 function header(text: string) {
-  return row(createLocation(0, 0, 0, text.length), [
-    new DataCell(text, createLocation(0, 0, 0, text.length)),
+  return headerWithStartIndex(text, 0);
+}
+
+function headerWithStartIndex(text: string, start: number) {
+  return row(createLocation(0, 0, 0, start + text.length), [
+    new DataCell(text, createLocation(0, start, 0, start + text.length)),
   ]);
 }
 
@@ -93,11 +97,11 @@ describe("TableReader", () => {
 
     const expected = [
       table("Table", {
-        header: header("*** Table"),
+        header: headerWithStartIndex("*** Table", 2),
         rows: [
-          row(createLocation(1, 0, 1, 13), [
-            new DataCell("cell1", createLocation(1, 0, 1, 5)),
-            new DataCell("cell2", createLocation(1, 8, 1, 13)),
+          row(createLocation(1, 0, 1, 15), [
+            new DataCell("cell1", createLocation(1, 2, 1, 7)),
+            new DataCell("cell2", createLocation(1, 10, 1, 15)),
           ]),
         ],
       }),
@@ -113,12 +117,12 @@ describe("TableReader", () => {
 
     const expected = [
       table("Table", {
-        header: header("*** Table"),
+        header: headerWithStartIndex("*** Table", 2),
         rows: [
-          row(createLocation(1, 0, 1, 16), [
-            new DataCell("", createLocation(1, 0, 1, 0)),
-            new DataCell("cell1", createLocation(1, 3, 1, 8)),
-            new DataCell("cell2", createLocation(1, 11, 1, 16)),
+          row(createLocation(1, 0, 1, 17), [
+            new DataCell("", createLocation(1, 1, 1, 1)),
+            new DataCell("cell1", createLocation(1, 4, 1, 9)),
+            new DataCell("cell2", createLocation(1, 12, 1, 17)),
           ]),
         ],
       }),
@@ -128,17 +132,21 @@ describe("TableReader", () => {
   });
 
   it("should not remove pipes from names", () => {
-    const data = `| *** Table\n| |cell1 | cell2|`;
+    const data = `| *** Table\n| |cell1 | cell2|\n| cell1| | |cell2`;
 
     const actual = reader.read(data);
 
     const expected = [
       table("Table", {
-        header: header("*** Table"),
+        header: headerWithStartIndex("*** Table", 2),
         rows: [
-          row(createLocation(1, 0, 1, 15), [
-            new DataCell("|cell1", createLocation(1, 0, 1, 6)),
-            new DataCell("cell2|", createLocation(1, 9, 1, 15)),
+          row(createLocation(1, 0, 1, 17), [
+            new DataCell("|cell1", createLocation(1, 2, 1, 8)),
+            new DataCell("cell2|", createLocation(1, 11, 1, 17)),
+          ]),
+          row(createLocation(2, 0, 2, 17), [
+            new DataCell("cell1|", createLocation(2, 2, 2, 8)),
+            new DataCell("|cell2", createLocation(2, 11, 2, 17)),
           ]),
         ],
       }),

--- a/server/src/parser/test/table-reader.test.ts
+++ b/server/src/parser/test/table-reader.test.ts
@@ -86,6 +86,67 @@ describe("TableReader", () => {
     chai.assert.deepEqual(actual, expected);
   });
 
+  it("should read single table with pipes", () => {
+    const data = `| *** Table\n| cell1 | cell2 |`;
+
+    const actual = reader.read(data);
+
+    const expected = [
+      table("Table", {
+        header: header("*** Table"),
+        rows: [
+          row(createLocation(1, 0, 1, 13), [
+            new DataCell("cell1", createLocation(1, 0, 1, 5)),
+            new DataCell("cell2", createLocation(1, 8, 1, 13)),
+          ]),
+        ],
+      }),
+    ];
+
+    chai.assert.deepEqual(actual, expected);
+  });
+
+  it("should parse empty first cell with pipes", () => {
+    const data = `| *** Table\n| | cell1 | cell2`;
+
+    const actual = reader.read(data);
+
+    const expected = [
+      table("Table", {
+        header: header("*** Table"),
+        rows: [
+          row(createLocation(1, 0, 1, 16), [
+            new DataCell("", createLocation(1, 0, 1, 0)),
+            new DataCell("cell1", createLocation(1, 3, 1, 8)),
+            new DataCell("cell2", createLocation(1, 11, 1, 16)),
+          ]),
+        ],
+      }),
+    ];
+
+    chai.assert.deepEqual(actual, expected);
+  });
+
+  it("should not remove pipes from names", () => {
+    const data = `| *** Table\n| |cell1 | cell2|`;
+
+    const actual = reader.read(data);
+
+    const expected = [
+      table("Table", {
+        header: header("*** Table"),
+        rows: [
+          row(createLocation(1, 0, 1, 15), [
+            new DataCell("|cell1", createLocation(1, 0, 1, 6)),
+            new DataCell("cell2|", createLocation(1, 9, 1, 15)),
+          ]),
+        ],
+      }),
+    ];
+
+    chai.assert.deepEqual(actual, expected);
+  });
+
   it("should ignore trailing whitespace", () => {
     const data = `*** Table\ncell1    `;
 


### PR DESCRIPTION
This PR supports the pipe separated format of robot. See issue #55.

I just added pipes to the cell separators and modified it to not only jump over whitespace but also pipes. I think it is not necessary to look 3 chars ahead for the whole pipe separation pattern " | " because the cell separator already handles this.

I am also trimming the leading and ending pipes. The tricky part hereby is that in case the first cell is empty, we need to keep the space behind the first pipe. Otherwise remove the pipe with the space.

```
"| Cell1" --> "Cell1"
"| | Cell1" --> " | Cell1"
```