### PR TITLE
fixed named argument matching to last "=", instead of first

### DIFF
--- a/client/syntaxes/robot.tmLanguage
+++ b/client/syntaxes/robot.tmLanguage
@@ -561,7 +561,7 @@
       <string>meta.named.argument.robot</string>
 
       <key>match</key>
-      <string>([^ |\t]*)((?<!\\)=)</string>
+      <string>((?<=[\s|])[^ |\t=]*)((?<!\\)=)</string>
 
       <key>captures</key>
       <dict>


### PR DESCRIPTION
Named variables were highlighted until last '='.
Changed regex to select first occurrence of '=' and
verify white space or '|' before.