### PR TITLE
add npm publish to server and client release process

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -6,9 +6,11 @@ rm -rf ./node_modules
 npm ci
 npm run clean
 npm run compile
+npm publish
 
 echo "Building client"
 cd ../client
 rm -rf ./node_modules
 npm ci
 vsce package
+npm publish


### PR DESCRIPTION
Sorry for the cheeky PR!

Thanks for the great tool!

A la #34, we would like to add RF LSP support for [another client](https://github.com/krassowski/jupyterlab-lsp). We've respect that a lot of servers will be built on the nodejs tooling, and go to great pains to support node-based language servers where possible (but are likewise trying to figure out how to bundle them for the browser, if possible).

It's somewhat unreasonable to expect end users to do git clone, add all  (at least) the server package would need to be accessible in a non-vscode places, which pretty much means npmjs (or I guess github, now, maybe). 